### PR TITLE
Improve contrast for alternating rows in Dolphin and make color schemes usable in Global Themes

### DIFF
--- a/Adflatus.colors
+++ b/Adflatus.colors
@@ -131,7 +131,7 @@ ForegroundPositive=39,174,96
 ForegroundVisited=155,89,182
 
 [General]
-ColorScheme=BreezeDark
+ColorScheme=Adflatus
 Name=Adflatus
 TintFactor=0.15
 TitlebarIsAccentColored=false

--- a/AdflatusHigherContrast.colors
+++ b/AdflatusHigherContrast.colors
@@ -104,7 +104,7 @@ ForegroundVisited=102,98,110
 
 [Colors:View]
 BackgroundAlternate=43,48,51
-BackgroundNormal=43,48,51
+BackgroundNormal=30,35,38
 DecorationFocus=138,132,148
 DecorationHover=138,132,148
 ForegroundActive=61,174,233
@@ -131,7 +131,7 @@ ForegroundPositive=39,174,96
 ForegroundVisited=102,98,110
 
 [General]
-ColorScheme=BreezeDark
+ColorScheme=AdflatusHigherContrast
 Name=Adflatus Higher Contrast
 TintFactor=0.15
 TitlebarIsAccentColored=false

--- a/AdflatusLight.colors
+++ b/AdflatusLight.colors
@@ -131,7 +131,7 @@ ForegroundPositive=39,174,96
 ForegroundVisited=155,89,182
 
 [General]
-ColorScheme=BreezeLight
+ColorScheme=AdflatusLight
 Name=Adflatus Light
 TintFactor=0.14
 TitlebarIsAccentColored=false


### PR DESCRIPTION
Improve contrast for alternating rows in Dolphin when the window is active while using the dark higher contrast scheme

Remove spaces from file name to allow referencing it from Global Themes 'default' file, e.g.

```
[kdeglobals][General]
ColorScheme=AdflatusHigherContrast
```

Change value of the `ColorScheme` attribute to allow to reference colors schemes from Global Themes